### PR TITLE
Added Load Last Prompt feature

### DIFF
--- a/modules/private_logger.py
+++ b/modules/private_logger.py
@@ -15,6 +15,11 @@ def log(img, dic, single_line_number=3, metadata=None, save_metadata_json=False,
         with open(json_path, 'w', encoding='utf-8') as json_file:
             json_file.write(metadata)
             json_file.close()
+        last_path = os.path.dirname(local_temp_filename) + "/../last.json"
+        with open(last_path, 'w', encoding='utf-8') as json_file:
+            json_file.write(metadata)
+            json_file.close()
+        
     
     if output_format == 'png':
         if save_metadata_image:

--- a/webui.py
+++ b/webui.py
@@ -22,7 +22,7 @@ from fastapi import FastAPI
 from modules.ui_gradio_extensions import reload_javascript
 from modules.util import get_current_log_path, get_previous_log_path
 from modules.auth import auth_enabled, check_auth
-from os.path import exists
+from os.path import exists, join
 
 
 GALLERY_ID_INPUT = 0
@@ -256,6 +256,21 @@ def load_prompt_handler(_file, *args):
                     print('load_prompt_handler, e: ' + str(e))
     return ctrls
 
+def load_last_prompt_handler(*args):
+    ctrls = list(args)
+    path = join(modules.path.temp_outputs_path, 'last.json')
+    if exists(path):
+        with open(path, encoding='utf-8') as json_file:
+            try:
+                json_obj = json.load(json_file)
+                metadata_to_ctrls(json_obj, ctrls)
+            except Exception as e:
+                print('load_last_prompt_handler, e: ' + str(e))
+            finally:
+                json_file.close()
+    return ctrls
+        
+
 
 def load_input_images_handler(files):
     return list(map(lambda x: x.name, files)), gr.update(selected=GALLERY_ID_INPUT), gr.update(value=len(files))
@@ -378,6 +393,7 @@ with shared.gradio_root:
                    same_seed_for_all = gr.Checkbox(label='Same seed for all images', value=settings['same_seed_for_all'])
                 image_seed = gr.Textbox(label='Seed', value=settings['seed'], max_lines=1, visible=not settings['seed_random'])
                 load_prompt_button = gr.UploadButton(label='Load Prompt', file_count='single', file_types=['.json', '.png', '.jpg'], elem_classes='type_small_row', min_width=0)
+                load_last_prompt_button = gr.Button(label='Load Last Prompt', value='Load Last Prompt', elem_classes='type_small_row', min_width=0)
 
                 def get_current_links():
                     return '<a href="https://github.com/lllyasviel/Fooocus/discussions/117">&#128212; Fooocus Advanced</a>' \
@@ -589,6 +605,8 @@ with shared.gradio_root:
         ctrls += [save_metadata_json, save_metadata_image] + img2img_ctrls + [same_seed_for_all, output_format]
         ctrls += canny_ctrls + depth_ctrls + [prompt_expansion] + freeu_ctrls
         load_prompt_button.upload(fn=load_prompt_handler, inputs=[load_prompt_button] + ctrls + [seed_random], outputs=ctrls + [seed_random])
+        load_last_prompt_button.click(fn=load_last_prompt_handler, inputs=ctrls + [seed_random], outputs=ctrls + [seed_random])
+
         ctrls += [input_image_checkbox, current_tab]
         ctrls += [uov_method, uov_input_image]
         ctrls += [outpaint_selections, inpaint_input_image]


### PR DESCRIPTION
Hello! Thanks for the great product.

As a user who accesses and uses the site remotely from a mobile device, I have been having trouble with pages frequently reloading and losing prompts and settings in the browser after not having the page open for a while.

So I modified it to write out the metadata from the last time the image was generated to the output directory with the file name "last.json". And I added a "Load Last Prompt" button under the "Load Prompt" button.

So far I'm finding it very useful and I think it will be useful for other users as well.