### PR TITLE
Add advanced log viewer

### DIFF
--- a/modules/private_logger.py
+++ b/modules/private_logger.py
@@ -1,5 +1,6 @@
 import os
 import modules.path
+import json
 
 from PIL import Image
 from PIL.PngImagePlugin import PngInfo
@@ -55,6 +56,23 @@ def log(img, dic, single_line_number=3, metadata=None, save_metadata_json=False,
             i += 1
         f.write(f"<p><img src=\"{only_name}\" width=512 onerror=\"document.getElementById('{div_name}').style.display = 'none';\"></img></p></div>\n")
 
+        all_json_name = os.path.join(os.path.dirname(local_temp_filename), 'all.json')
+
+        if not os.path.exists(all_json_name):
+            with open(all_json_name, 'w', encoding='utf-8') as f:
+                f.write('{"data": []}')
+
+        with open(all_json_name, 'r', encoding='utf-8') as f:
+            all_json = json.load(f)
+
+        new_data = {
+            "src": only_name,
+        }
+        new_data.update(dic)
+        all_json["data"].append(new_data)
+        with open(all_json_name, 'w', encoding='utf-8') as f:
+            json.dump(all_json, f)
+    
     print(f'Image generated with private log at: {html_name}')
 
     return


### PR DESCRIPTION
Hi, I am building a log viewer for myself to better view the log of images generated by Fooocus-MRE. I think it would be quite useful, so I'm submitting a pull request.

Features:
- One HTML file. no additional backend, no npm install
- Quick date selection
- Auto reload (if today)
- Group images by batch of image generation
- Show Diff with prompts from previous batch
- Sort images (newest first, oldest first)
- Can choose how many images to load at once (important for mobile users like me).
- Easy grid resizing

This commit automatically creates a file named `all.json` in the `outputs/XX-XX-XX` directory and consolidates the logged information.
Then, if you place the attached `viewer.html` directly under the outputs directory, you can use the viewer by accessing `/file=outputs/viewer.html` on the local server.

What I am having trouble with is that the outputs directory is in the .`gitignore` , so I need to keep the `viewer.html` somewhere in the repository and copy it over during the log generation phase. Where should I place it?

[viewer.html.zip](https://github.com/MoonRide303/Fooocus-MRE/files/12777331/viewer.html.zip)
